### PR TITLE
Fix MainActor run call in content view

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -147,7 +147,8 @@ struct ContentView: View {
             if let frame = sampleBuffer.imageBuffer {
                 displayCont.yield(frame)
                 await MainActor.run { latestFrame = frame }
-                if await MainActor.run({ isRealTime }) {
+                let realtime = await MainActor.run { self.isRealTime }
+                if realtime {
                     analyzeCont.yield(frame)
                 }
             }


### PR DESCRIPTION
## Summary
- correct MainActor access to `isRealTime` when distributing video frames

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dc1d23e40832ab87dfa10dce7c618