### PR TITLE
Add photo preview and sharing flow

### DIFF
--- a/app/FastVLM App/Info.plist
+++ b/app/FastVLM App/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Allow FastVLM to save photos to your library.</string>
+</dict>
 </plist>

--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -1,0 +1,123 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import SwiftUI
+import Photos
+#if os(iOS)
+import UIKit
+
+struct PhotoPreviewView: View {
+    let image: UIImage
+    @Binding var description: String
+    let prompt: String
+    var onRetake: () -> Void
+
+    @State private var showPrompt = false
+    @State private var showShare = false
+
+    var body: some View {
+        ZStack {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .ignoresSafeArea()
+
+            VStack {
+                HStack {
+                    Button {
+                    } label: {
+                        Label("Original", systemImage: "sparkles")
+                            .padding(8)
+                            .background(.ultraThinMaterial)
+                            .cornerRadius(8)
+                    }
+                    Spacer()
+                    Button {
+                        showPrompt = true
+                    } label: {
+                        Label("Info", systemImage: "info.circle")
+                            .padding(8)
+                            .background(.ultraThinMaterial)
+                            .cornerRadius(8)
+                    }
+                }
+                .padding()
+                .foregroundStyle(.white)
+
+                Spacer()
+
+                if !description.isEmpty {
+                    Text(description)
+                        .foregroundStyle(.white)
+                        .padding(8)
+                        .background(Color.black.opacity(0.6))
+                        .cornerRadius(8)
+                        .padding()
+                }
+
+                HStack(spacing: 40) {
+                    Button {
+                        onRetake()
+                    } label: {
+                        VStack {
+                            Image(systemName: "camera")
+                            Text("New Photo")
+                                .font(.caption)
+                        }
+                    }
+
+                    Button {
+                        savePhoto()
+                    } label: {
+                        VStack {
+                            Image(systemName: "square.and.arrow.down")
+                            Text("Save")
+                                .font(.caption)
+                        }
+                    }
+
+                    Button {
+                        showShare = true
+                    } label: {
+                        VStack {
+                            Image(systemName: "square.and.arrow.up")
+                            Text("Share")
+                                .font(.caption)
+                        }
+                    }
+                    .sheet(isPresented: $showShare) {
+                        ShareSheet(activityItems: [image])
+                    }
+                }
+                .padding(.bottom, 40)
+                .foregroundStyle(.white)
+            }
+        }
+        .alert("Prompt", isPresented: $showPrompt) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(prompt)
+        }
+    }
+
+    func savePhoto() {
+        PHPhotoLibrary.requestAuthorization { status in
+            if status == .authorized || status == .limited {
+                UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+            }
+        }
+    }
+}
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+#endif


### PR DESCRIPTION
## Summary
- Capture a still photo and show preview with description when the shutter button is pressed
- Add preview screen with Info, Original, New Photo, Save and Share actions
- Enable saving to Photos by including usage description

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6a786b4832ab97e76251ad9f8ff