### PR TITLE
feat: generate images with playground

### DIFF
--- a/app/FastVLM App/ImageGenerator.swift
+++ b/app/FastVLM App/ImageGenerator.swift
@@ -1,0 +1,34 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import Foundation
+#if os(iOS)
+import UIKit
+import ImagePlayground
+
+/// Wrapper around Image Playground to generate images in the background.
+@MainActor
+class PlaygroundImageGenerator {
+    private let session: PlaygroundSession?
+
+    init() {
+        session = try? PlaygroundSession()
+    }
+
+    /// Generate a new image based on the provided one using Image Playground.
+    /// - Parameter image: Source image.
+    /// - Returns: Generated image or nil if generation fails.
+    func generate(from image: UIImage) async -> UIImage? {
+        guard let session else { return nil }
+        do {
+            let request = PlaygroundImageRequest(referenceImage: image)
+            let result = try await session.image(from: request)
+            return result
+        } catch {
+            return nil
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add Image Playground generator to create stylized versions in background
- allow preview screen to toggle between original and generated photos
- save and share both original and generated images

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dcb7ff188832abc2e280dee155c04