### PR TITLE
Conditional ImagePlayground integration

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -11,7 +11,8 @@ import CoreImage
 #if os(iOS)
 import UIKit
 #endif
-#if os(iOS)
+#if os(iOS) && canImport(ImagePlayground)
+@available(iOS 18.0, *)
 import ImagePlayground
 #endif
 
@@ -39,6 +40,9 @@ struct ContentView: View {
     @State private var showPreview: Bool = false
 #if os(iOS)
     @State private var generatedImage: UIImage?
+#endif
+#if os(iOS) && canImport(ImagePlayground)
+    @available(iOS 18.0, *)
     @State private var imageGenerator = PlaygroundImageGenerator()
 #endif
 
@@ -98,15 +102,15 @@ struct ContentView: View {
 #if os(iOS)
                             generatedImage = nil
 #endif
-                            showPreview = true
-                            showDescription = true
-#if os(iOS)
-                            if let capturedImage {
+#if os(iOS) && canImport(ImagePlayground)
+                            if #available(iOS 18.0, *), let capturedImage {
                                 Task {
                                     generatedImage = await imageGenerator.generate(from: capturedImage)
                                 }
                             }
 #endif
+                            showPreview = true
+                            showDescription = true
                         }
                     } label: {
                         Circle()

--- a/app/FastVLM App/ImageGenerator.swift
+++ b/app/FastVLM App/ImageGenerator.swift
@@ -6,10 +6,13 @@
 import Foundation
 #if os(iOS)
 import UIKit
+#if canImport(ImagePlayground)
+@available(iOS 18.0, *)
 import ImagePlayground
 
 /// Wrapper around Image Playground to generate images in the background.
 @MainActor
+@available(iOS 18.0, *)
 class PlaygroundImageGenerator {
     private let session: PlaygroundSession?
 
@@ -31,4 +34,16 @@ class PlaygroundImageGenerator {
         }
     }
 }
+#else
+@MainActor
+@available(iOS 18.0, *)
+class PlaygroundImageGenerator {
+    init() {}
+
+    /// Stub generator when ImagePlayground is unavailable.
+    /// - Parameter image: Source image.
+    /// - Returns: Always nil.
+    func generate(from image: UIImage) async -> UIImage? { nil }
+}
+#endif
 #endif


### PR DESCRIPTION
## Summary
- wrap ImagePlayground usage in `#if canImport(ImagePlayground)` with iOS 18 availability checks
- provide stubbed `PlaygroundImageGenerator` when framework missing

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dce8dee48832ab7d75837dc4a0965