### PR TITLE
Refine camera and preview UI for consistent styling

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -54,16 +54,6 @@ struct ContentView: View {
                     action: nil
                 )
                 .ignoresSafeArea()
-                #if !os(macOS)
-                .overlay(alignment: .topLeading) {
-                    CameraControlsView(
-                        backCamera: $camera.backCamera,
-                        device: $camera.device,
-                        devices: $camera.devices
-                    )
-                    .padding()
-                }
-                #endif
             } else {
                 Color.black.ignoresSafeArea()
             }
@@ -94,31 +84,45 @@ struct ContentView: View {
                             .cornerRadius(8)
                     }
 
-                    Button {
-                        if !isRealTime, let frame = latestFrame {
-                            processSingleFrame(frame)
-                            capturedImage = makeUIImage(from: frame)
+                    HStack(spacing: 40) {
+                        Button {
+                            camera.backCamera.toggle()
+                        } label: {
+                            Circle()
+                                .fill(Color.black.opacity(0.6))
+                                .frame(width: 50, height: 50)
+                                .overlay(
+                                    Image(systemName: "arrow.triangle.2.circlepath.camera")
+                                        .foregroundStyle(.white)
+                                )
+                        }
+
+                        Button {
+                            if !isRealTime, let frame = latestFrame {
+                                processSingleFrame(frame)
+                                capturedImage = makeUIImage(from: frame)
 #if os(iOS)
-                            generatedImage = nil
+                                generatedImage = nil
 #endif
 #if os(iOS) && canImport(ImagePlayground)
-                            if #available(iOS 18.0, *), let capturedImage {
-                                Task {
-                                    generatedImage = await imageGenerator.generate(from: capturedImage)
+                                if #available(iOS 18.0, *), let capturedImage {
+                                    Task {
+                                        generatedImage = await imageGenerator.generate(from: capturedImage)
+                                    }
                                 }
-                            }
 #endif
-                            showPreview = true
-                            showDescription = true
+                                showPreview = true
+                                showDescription = true
+                            }
+                        } label: {
+                            Circle()
+                                .fill(Color.white)
+                                .frame(width: 70, height: 70)
+                                .overlay(
+                                    Circle()
+                                        .stroke(Color.black.opacity(0.2), lineWidth: 2)
+                                )
                         }
-                    } label: {
-                        Circle()
-                            .fill(Color.white)
-                            .frame(width: 70, height: 70)
-                            .overlay(
-                                Circle()
-                                    .stroke(Color.black.opacity(0.2), lineWidth: 2)
-                            )
                     }
                 }
                 .padding(.bottom, 40)

--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -18,6 +18,7 @@ struct PhotoPreviewView: View {
     @State private var showPrompt = false
     @State private var showShare = false
     @State private var selection: ImageSelection = .original
+    private let buttonSize: CGFloat = 70
 
     enum ImageSelection: String, CaseIterable, Identifiable {
         case original
@@ -35,28 +36,32 @@ struct PhotoPreviewView: View {
             VStack {
                 HStack {
                     if generatedImage != nil {
-                        Picker("", selection: $selection) {
-                            Text("Original").tag(ImageSelection.original)
-                            Text("Generated").tag(ImageSelection.generated)
+                        Button {
+                            selection = selection == .original ? .generated : .original
+                        } label: {
+                            Text(selection == .generated ? "Original" : "Generated")
+                                .frame(width: buttonSize, height: buttonSize)
+                                .background(Color.black)
+                                .cornerRadius(12)
                         }
-                        .pickerStyle(.segmented)
-                        .padding(8)
-                        .background(.ultraThinMaterial)
-                        .cornerRadius(8)
                     } else {
-                        Label("Original", systemImage: "sparkles")
-                            .padding(8)
-                            .background(.ultraThinMaterial)
-                            .cornerRadius(8)
+                        Text("Original")
+                            .frame(width: buttonSize, height: buttonSize)
+                            .background(Color.black)
+                            .cornerRadius(12)
                     }
                     Spacer()
                     Button {
                         showPrompt = true
                     } label: {
-                        Label("Info", systemImage: "info.circle")
-                            .padding(8)
-                            .background(.ultraThinMaterial)
-                            .cornerRadius(8)
+                        VStack {
+                            Image(systemName: "info.circle")
+                            Text("Info")
+                                .font(.caption)
+                        }
+                        .frame(width: buttonSize, height: buttonSize)
+                        .background(Color.black)
+                        .cornerRadius(12)
                     }
                 }
                 .padding()
@@ -73,7 +78,7 @@ struct PhotoPreviewView: View {
                         .padding()
                 }
 
-                HStack(spacing: 40) {
+                HStack(spacing: 20) {
                     Button {
                         onRetake()
                     } label: {
@@ -82,6 +87,9 @@ struct PhotoPreviewView: View {
                             Text("New Photo")
                                 .font(.caption)
                         }
+                        .frame(width: buttonSize, height: buttonSize)
+                        .background(Color.black)
+                        .cornerRadius(12)
                     }
 
                     Button {
@@ -92,6 +100,9 @@ struct PhotoPreviewView: View {
                             Text("Save")
                                 .font(.caption)
                         }
+                        .frame(width: buttonSize, height: buttonSize)
+                        .background(Color.black)
+                        .cornerRadius(12)
                     }
 
                     Button {
@@ -102,6 +113,9 @@ struct PhotoPreviewView: View {
                             Text("Share")
                                 .font(.caption)
                         }
+                        .frame(width: buttonSize, height: buttonSize)
+                        .background(Color.black)
+                        .cornerRadius(12)
                     }
                     .sheet(isPresented: $showShare) {
                         ShareSheet(activityItems: [image, generatedImage].compactMap { $0 })
@@ -109,6 +123,11 @@ struct PhotoPreviewView: View {
                 }
                 .padding(.bottom, 40)
                 .foregroundStyle(.white)
+            }
+        }
+        .onChange(of: generatedImage) { newValue in
+            if newValue != nil {
+                selection = .generated
             }
         }
         .alert("Prompt", isPresented: $showPrompt) {


### PR DESCRIPTION
## Summary
- Style results screen buttons with uniform square black design and toggle between original and generated images
- Auto-switch to the generated image when available
- Add camera switch control beside shutter button on capture screen

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dd6f3da64832a918beeb206d21794