### PR TITLE
Add settings button for prompt and image style customization

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -43,6 +43,8 @@ struct ContentView: View {
 #if os(iOS) && canImport(ImagePlayground)
     @available(iOS 18.0, *)
     @State private var imageGenerator = PlaygroundImageGenerator()
+    @available(iOS 18.0, *)
+    @State private var playgroundStyle: PlaygroundStyle = .sketch
 #endif
 
     var body: some View {
@@ -107,7 +109,7 @@ struct ContentView: View {
 #if os(iOS) && canImport(ImagePlayground)
                                 if #available(iOS 18.0, *), let capturedImage {
                                     Task {
-                                        generatedImage = await imageGenerator.generate(from: capturedImage)
+                                        generatedImage = await imageGenerator.generate(from: capturedImage, style: playgroundStyle)
                                     }
                                 }
 #endif
@@ -143,7 +145,9 @@ struct ContentView: View {
                 PhotoPreviewView(
                     image: capturedImage,
                     generatedImage: $generatedImage,
-                    description: $model.output
+                    description: $model.output,
+                    prompt: $prompt,
+                    style: $playgroundStyle
                 ) {
                     showPreview = false
                     model.output = ""

--- a/app/FastVLM App/ImageGenerator.swift
+++ b/app/FastVLM App/ImageGenerator.swift
@@ -8,7 +8,16 @@ import Foundation
 import UIKit
 #if canImport(ImagePlayground)
 import ImagePlayground
+#endif
 
+/// Style options for Image Playground generation.
+enum PlaygroundStyle: String, CaseIterable, Identifiable {
+    case sketch
+    case realistic
+    var id: String { rawValue }
+}
+
+#if canImport(ImagePlayground)
 /// Wrapper around Image Playground to generate images in the background.
 @MainActor
 @available(iOS 18.0, *)
@@ -18,16 +27,19 @@ class PlaygroundImageGenerator {
     init() {}
 
     /// Generate a new image based on the provided one using Image Playground.
-    /// - Parameter image: Source image.
+    /// - Parameters:
+    ///   - image: Source image.
+    ///   - style: Desired generation style.
     /// - Returns: Generated image or nil if generation fails.
-    func generate(from image: UIImage) async -> UIImage? {
+    func generate(from image: UIImage, style: PlaygroundStyle) async -> UIImage? {
         do {
             if creator == nil {
                 creator = try await ImageCreator()
             }
             guard let creator, let cgImage = image.cgImage else { return nil }
             let concepts: [ImagePlaygroundConcept] = [.image(cgImage)]
-            let images = creator.images(for: concepts, style: .sketch, limit: 1)
+            let playgroundStyle = ImagePlaygroundStyle(rawValue: style.rawValue) ?? .sketch
+            let images = creator.images(for: concepts, style: playgroundStyle, limit: 1)
             for try await result in images {
                 return UIImage(cgImage: result.cgImage)
             }
@@ -44,9 +56,11 @@ class PlaygroundImageGenerator {
     init() {}
 
     /// Stub generator when ImagePlayground is unavailable.
-    /// - Parameter image: Source image.
+    /// - Parameters:
+    ///   - image: Source image.
+    ///   - style: Desired generation style.
     /// - Returns: Always nil.
-    func generate(from image: UIImage) async -> UIImage? { nil }
+    func generate(from image: UIImage, style: PlaygroundStyle) async -> UIImage? { nil }
 }
 #endif
 #endif

--- a/app/FastVLM App/ImageGenerator.swift
+++ b/app/FastVLM App/ImageGenerator.swift
@@ -38,7 +38,18 @@ class PlaygroundImageGenerator {
             }
             guard let creator, let cgImage = image.cgImage else { return nil }
             let concepts: [ImagePlaygroundConcept] = [.image(cgImage)]
-            let playgroundStyle = ImagePlaygroundStyle(rawValue: style.rawValue) ?? .sketch
+
+            // Map our simple `PlaygroundStyle` to the corresponding
+            // `ImagePlaygroundStyle`. The ImagePlayground API doesn't expose
+            // a `RawRepresentable` initializer, so we translate explicitly.
+            let playgroundStyle: ImagePlaygroundStyle
+            switch style {
+            case .sketch:
+                playgroundStyle = .sketch
+            case .realistic:
+                playgroundStyle = .realistic
+            }
+
             let images = creator.images(for: concepts, style: playgroundStyle, limit: 1)
             for try await result in images {
                 return UIImage(cgImage: result.cgImage)

--- a/app/FastVLM App/ImageGenerator.swift
+++ b/app/FastVLM App/ImageGenerator.swift
@@ -13,7 +13,8 @@ import ImagePlayground
 /// Style options for Image Playground generation.
 enum PlaygroundStyle: String, CaseIterable, Identifiable {
     case sketch
-    case realistic
+    case illustration
+    case animation
     var id: String { rawValue }
 }
 
@@ -46,8 +47,10 @@ class PlaygroundImageGenerator {
             switch style {
             case .sketch:
                 playgroundStyle = .sketch
-            case .realistic:
-                playgroundStyle = .realistic
+            case .illustration:
+                playgroundStyle = .illustration
+            case .animation:
+                playgroundStyle = .animation
             }
 
             let images = creator.images(for: concepts, style: playgroundStyle, limit: 1)

--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -114,6 +114,7 @@ struct PhotoPreviewView: View {
                             )
                         }
                     }
+                    .frame(maxWidth: .infinity)
                     .padding(.horizontal, 30)
                     .padding(.top, 60)
 
@@ -180,6 +181,7 @@ struct PhotoPreviewView: View {
                             ShareSheet(activityItems: [image, generatedImage].compactMap { $0 })
                         }
                     }
+                    .frame(maxWidth: .infinity)
                     .padding(.horizontal, 30)
                     .padding(.bottom, 50)
                 }
@@ -226,7 +228,7 @@ struct PhotoPreviewView: View {
             }
         }
         .ignoresSafeArea()
-        .onChange(of: generatedImage) { newValue in
+        .onChange(of: generatedImage) { _, newValue in
             if newValue != nil {
                 selection = .generated
             }

--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -12,10 +12,13 @@ struct PhotoPreviewView: View {
     let image: UIImage
     @Binding var generatedImage: UIImage?
     @Binding var description: String
+    @Binding var prompt: String
+    @Binding var style: PlaygroundStyle
     var onRetake: () -> Void
 
     @State private var showingDescription = false
     @State private var showShare = false
+    @State private var showSettings = false
     @State private var selection: ImageSelection = .original
     private let buttonSize: CGFloat = 80
 
@@ -72,8 +75,26 @@ struct PhotoPreviewView: View {
                             )
                         }
 
-                        Spacer()
+                        Button {
+                            showSettings = true
+                        } label: {
+                            VStack(spacing: 6) {
+                                Image(systemName: "gearshape.fill")
+                                    .font(.title)
+                                Text("Settings")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            .foregroundColor(.white)
+                            .frame(width: buttonSize, height: buttonSize)
+                            .background(Color.black.opacity(0.8))
+                            .cornerRadius(16)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                            )
+                        }
 
+        
                         Button {
                             showingDescription.toggle()
                         } label: {
@@ -209,6 +230,9 @@ struct PhotoPreviewView: View {
             if newValue != nil {
                 selection = .generated
             }
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView(prompt: $prompt, style: $style)
         }
     }
 

--- a/app/FastVLM App/SettingsView.swift
+++ b/app/FastVLM App/SettingsView.swift
@@ -1,0 +1,39 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var prompt: String
+    @Binding var style: PlaygroundStyle
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Prompt") {
+                    TextField("Prompt", text: $prompt)
+                }
+                Section("Image Style") {
+                    Picker("Style", selection: $style) {
+                        ForEach(PlaygroundStyle.allCases) { option in
+                            Text(option.rawValue.capitalized).tag(option)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView(prompt: .constant("Describe the image"), style: .constant(.sketch))
+}


### PR DESCRIPTION
## Summary
- Add Settings view to edit FastVLM prompt and Image Playground style
- Add Settings button in photo preview and pass prompt/style bindings through
- Update image generator to support style selection

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689ddff813e0832a8033e37790f4da50