### PR TITLE
Persist settings and show image generation status

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
     @State private var framesToDisplay: AsyncStream<CVImageBuffer>?
     @State private var latestFrame: CVImageBuffer?
 
-    @State private var prompt = "Describe the image in English."
+    @AppStorage("prompt") private var prompt = "Describe the image in English."
     @State private var promptSuffix = "Output should be brief, about 15 words or less."
 
     @State private var isRealTime: Bool = false
@@ -44,7 +44,7 @@ struct ContentView: View {
     @available(iOS 18.0, *)
     @State private var imageGenerator = PlaygroundImageGenerator()
     @available(iOS 18.0, *)
-    @State private var playgroundStyle: PlaygroundStyle = .sketch
+    @AppStorage("playgroundStyle") private var playgroundStyle: PlaygroundStyle = .sketch
 #endif
 
     var body: some View {

--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -37,6 +37,23 @@ struct PhotoPreviewView: View {
                     .frame(width: geometry.size.width, height: geometry.size.height)
                     .clipped()
 
+                if generatedImage == nil {
+                    VStack {
+                        Text("Generating image")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                        Text(prompt)
+                            .font(.subheadline)
+                            .foregroundColor(.white)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
+                    .background(Color.black.opacity(0.6))
+                    .cornerRadius(12)
+                    .padding(.top, 30)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                }
+
                 VStack {
                     HStack(spacing: 20) {
                         if generatedImage != nil {
@@ -62,7 +79,7 @@ struct PhotoPreviewView: View {
                             VStack(spacing: 6) {
                                 Image(systemName: "photo")
                                     .font(.title)
-                                Text("Original")
+                                Text("Generated")
                                     .font(.system(size: 12, weight: .medium))
                             }
                             .foregroundColor(.white)


### PR DESCRIPTION
## Summary
- persist prompt and image style selections using `AppStorage`
- indicate generated-image progress in preview with a status overlay
- rename original-image toggle button to "Generated" while generation runs

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689deb05a400832a9ef4330249538e30