### PR TITLE
Ensure shutter works after toggling real-time descriptions

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -88,7 +88,12 @@ struct ContentView: View {
                         Spacer()
 
                         Button {
-                            if !isRealTime, let frame = latestFrame {
+                            if let frame = latestFrame {
+                                if isRealTime {
+                                    isRealTime = false
+                                    showDescription = false
+                                    model.cancel()
+                                }
                                 processSingleFrame(frame)
                                 capturedImage = makeUIImage(from: frame)
 #if os(iOS)


### PR DESCRIPTION
## Summary
- allow shutter to capture even after the text description button toggles real-time mode
- cancel real-time processing when shutter is pressed to return to single-frame capture

## Testing
- `swift build --package-path "app/FastVLM App"` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_689edc12df68832a8e5e43a5d8fb3e80