### PR TITLE
Remove prompt customization and persistence

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
     @State private var framesToDisplay: AsyncStream<CVImageBuffer>?
     @State private var latestFrame: CVImageBuffer?
 
-    @AppStorage("prompt") private var prompt = "Describe the image in English."
+    private let prompt = "Describe the image in English."
     @State private var promptSuffix = "Output should be brief, about 15 words or less."
 
     @State private var isRealTime: Bool = false
@@ -151,7 +151,7 @@ struct ContentView: View {
                     image: capturedImage,
                     generatedImage: $generatedImage,
                     description: $model.output,
-                    prompt: $prompt,
+                    prompt: prompt,
                     style: $playgroundStyle
                 ) {
                     showPreview = false

--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -12,7 +12,7 @@ struct PhotoPreviewView: View {
     let image: UIImage
     @Binding var generatedImage: UIImage?
     @Binding var description: String
-    @Binding var prompt: String
+    let prompt: String
     @Binding var style: PlaygroundStyle
     var onRetake: () -> Void
 
@@ -256,7 +256,7 @@ struct PhotoPreviewView: View {
             }
         )
         .sheet(isPresented: $showSettings) {
-            SettingsView(prompt: $prompt, style: $style)
+            SettingsView(style: $style)
         }
     }
 

--- a/app/FastVLM App/SettingsView.swift
+++ b/app/FastVLM App/SettingsView.swift
@@ -7,15 +7,11 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
-    @Binding var prompt: String
     @Binding var style: PlaygroundStyle
 
     var body: some View {
         NavigationStack {
             Form {
-                Section("Prompt") {
-                    TextField("Prompt", text: $prompt)
-                }
                 Section("Image Style") {
                     Picker("Style", selection: $style) {
                         ForEach(PlaygroundStyle.allCases) { option in
@@ -35,5 +31,5 @@ struct SettingsView: View {
 }
 
 #Preview {
-    SettingsView(prompt: .constant("Describe the image"), style: .constant(.sketch))
+    SettingsView(style: .constant(.sketch))
 }


### PR DESCRIPTION
## Summary
- Drop prompt field from `SettingsView` so only image style can be adjusted
- Use a constant prompt instead of persisted `@AppStorage`
- Update `PhotoPreviewView` to accept constant prompt and new `SettingsView` API

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689edd1cb02c832a976f9b2467f52fe7