### PR TITLE
feat: improve camera preview description handling

### DIFF
--- a/app/FastVLM App/PhotoPreviewView.swift
+++ b/app/FastVLM App/PhotoPreviewView.swift
@@ -132,10 +132,12 @@ struct PhotoPreviewView: View {
                             Text("Generating image")
                                 .font(.headline)
                                 .foregroundColor(.white)
-                            Text(description)
-                                .font(.subheadline)
-                                .foregroundColor(.white)
-                                .multilineTextAlignment(.center)
+                            if !description.isEmpty {
+                                Text(description)
+                                    .font(.subheadline)
+                                    .foregroundColor(.white)
+                                    .multilineTextAlignment(.center)
+                            }
                         }
                         .padding()
                         .background(Color.black.opacity(0.6))


### PR DESCRIPTION
## Summary
- hide camera overlay when description text is empty
- show only short description during image generation and defer long description
- avoid blank preview text when generating images

## Testing
- `swiftc -typecheck "app/FastVLM App/ContentView.swift"` *(fails: no such module 'AVFoundation')*
- `swiftc -typecheck "app/FastVLM App/PhotoPreviewView.swift"` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689f2b1ac370832aa076595e6bc91222