### PR TITLE
Add welcome screen with app details and first-run logic

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -61,6 +61,8 @@ struct ContentView: View {
     @available(iOS 18.0, *)
     @AppStorage("playgroundStyle") private var playgroundStyle: PlaygroundStyle = .sketch
 #endif
+    @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
+    @State private var showWelcome: Bool = false
 
     var body: some View {
         ZStack {
@@ -169,6 +171,11 @@ struct ContentView: View {
         .task {
             await distributeVideoFrames()
         }
+        .onAppear {
+            if !hasSeenWelcome {
+                showWelcome = true
+            }
+        }
         #if os(iOS)
         .onAppear {
             UIApplication.shared.isIdleTimerDisabled = true
@@ -191,11 +198,14 @@ struct ContentView: View {
                             },
                             onRecreate: { style in
                                 recreateImage(style: style)
-                            }
-                        )
+        }
+        )
             }
         }
 #endif
+        .sheet(isPresented: $showWelcome, onDismiss: { hasSeenWelcome = true }) {
+            WelcomeView()
+        }
         .sheet(isPresented: $showSettings) {
             SettingsView(
                 style: $playgroundStyle,

--- a/app/FastVLM App/MoreView.swift
+++ b/app/FastVLM App/MoreView.swift
@@ -12,6 +12,7 @@ struct MoreView: View {
     @Environment(\.dismiss) private var dismiss
     let shortDescription: String
     let longDescription: String
+    @State private var showWelcome = false
 
     var body: some View {
         NavigationStack {
@@ -40,12 +41,18 @@ struct MoreView: View {
                         }
                     }
                 }
+                Section("About") {
+                    Button("Welcome Screen") { showWelcome = true }
+                }
             }
             .navigationTitle("More")
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .sheet(isPresented: $showWelcome) {
+                WelcomeView()
             }
         }
     }

--- a/app/FastVLM App/SettingsView.swift
+++ b/app/FastVLM App/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @Binding var mode: DescriptionMode
     @Binding var isRealTime: Bool
     @Binding var showDescription: Bool
+    @State private var showWelcome = false
 
     var body: some View {
         NavigationStack {
@@ -37,12 +38,19 @@ struct SettingsView: View {
                         }
                     }
                 }
+
+                Section("About") {
+                    Button("Welcome Screen") { showWelcome = true }
+                }
             }
             .navigationTitle("Settings")
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .sheet(isPresented: $showWelcome) {
+                WelcomeView()
             }
         }
     }

--- a/app/FastVLM App/WelcomeView.swift
+++ b/app/FastVLM App/WelcomeView.swift
@@ -1,0 +1,57 @@
+//
+//  WelcomeView.swift
+//
+//  For licensing see accompanying LICENSE file.
+//
+
+import SwiftUI
+
+struct WelcomeView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private var appName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FastVLM"
+    }
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(appName)
+                        .font(.largeTitle)
+                        .bold()
+                    Text("Version \(appVersion)")
+                        .font(.subheadline)
+                    Divider()
+                    Text("This app is based on:")
+                        .font(.headline)
+                    Link("ml-fastvlm on GitHub", destination: URL(string: "https://github.com/apple/ml-fastvlm")!)
+                    Link("Apple Intelligence Playground", destination: URL(string: "https://developer.apple.com/machine-learning/apple-intelligence-playground/")!)
+                    Divider()
+                    Text("This app runs entirely on device and does not communicate with any servers.")
+                    Text("Author: Luiz Pizzato. This project was made for fun.")
+                    Link("Blog post about this project", destination: URL(string: "https://example.com")!)
+                }
+                .multilineTextAlignment(.leading)
+                .padding()
+            }
+            .navigationTitle("Welcome")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    WelcomeView()
+}


### PR DESCRIPTION
## Summary
- Introduce `WelcomeView` displaying app name, version, links to ml-fastvlm and Apple Intelligence Playground, on-device notice, and author info
- Present welcome screen on first launch and expose it via Settings and More screens
- Track first-run status with `AppStorage`

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_689f35a61ab8832a872d753559a979eb